### PR TITLE
[#37] Feat/37/마이페이지

### DIFF
--- a/src/apis/file/file.queries.ts
+++ b/src/apis/file/file.queries.ts
@@ -1,0 +1,13 @@
+import { useMutation } from '@tanstack/react-query';
+import { useSession } from 'next-auth/react';
+import { uploadFile } from './file.service';
+import type { UploadFileRequest } from './file.type';
+
+export const useUploadFileMutation = () => {
+  const { data: session } = useSession();
+  const accessToken = session?.accessToken ?? '';
+
+  return useMutation({
+    mutationFn: (req: UploadFileRequest) => uploadFile(req, accessToken),
+  });
+};

--- a/src/apis/file/file.service.ts
+++ b/src/apis/file/file.service.ts
@@ -1,0 +1,32 @@
+import { ApiError } from '@/utils/apiError';
+import type { UploadFileRequest, UploadFileResponse } from './file.type';
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+export const uploadFile = async (
+  { file, type, workspaceId }: UploadFileRequest,
+  accessToken: string,
+): Promise<UploadFileResponse> => {
+  const params = new URLSearchParams({ type });
+  if (workspaceId !== undefined) {
+    params.append('workspaceId', String(workspaceId));
+  }
+
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const res = await fetch(`${BASE_URL}/api/v1/files?${params.toString()}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: formData,
+  });
+
+  if (!res.ok) {
+    throw new ApiError('파일 업로드 실패.', res.status);
+  }
+
+  const json = (await res.json()) as { data: UploadFileResponse };
+  return json.data;
+};

--- a/src/apis/file/file.type.ts
+++ b/src/apis/file/file.type.ts
@@ -1,0 +1,11 @@
+export type FileUploadType = 'PROFILE' | 'RECEIPT';
+
+export interface UploadFileRequest {
+  file: File;
+  type: FileUploadType;
+  workspaceId?: number;
+}
+
+export interface UploadFileResponse {
+  fileId: number;
+}

--- a/src/apis/user/user.queries.ts
+++ b/src/apis/user/user.queries.ts
@@ -1,0 +1,35 @@
+import { useMutation } from '@tanstack/react-query';
+import { useSession } from 'next-auth/react';
+import { updateName, updatePassword, updateProfileImage } from './user.service';
+import type {
+  UpdateNameRequest,
+  UpdatePasswordRequest,
+  UpdateProfileImageRequest,
+} from './user.type';
+
+export const useUpdateNameMutation = () => {
+  const { data: session } = useSession();
+  const accessToken = session?.accessToken ?? '';
+
+  return useMutation({
+    mutationFn: (req: UpdateNameRequest) => updateName(req, accessToken),
+  });
+};
+
+export const useUpdateProfileImageMutation = () => {
+  const { data: session } = useSession();
+  const accessToken = session?.accessToken ?? '';
+
+  return useMutation({
+    mutationFn: (req: UpdateProfileImageRequest) => updateProfileImage(req, accessToken),
+  });
+};
+
+export const useUpdatePasswordMutation = () => {
+  const { data: session } = useSession();
+  const accessToken = session?.accessToken ?? '';
+
+  return useMutation({
+    mutationFn: (req: UpdatePasswordRequest) => updatePassword(req, accessToken),
+  });
+};

--- a/src/apis/user/user.service.ts
+++ b/src/apis/user/user.service.ts
@@ -1,0 +1,63 @@
+import { ApiError } from '@/utils/apiError';
+import type {
+  UpdateNameRequest,
+  UpdatePasswordRequest,
+  UpdateProfileImageRequest,
+  UserProfile,
+} from './user.type';
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+export const updateName = async (
+  body: UpdateNameRequest,
+  accessToken: string,
+): Promise<UserProfile> => {
+  const res = await fetch(`${BASE_URL}/api/v1/users/me`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) throw new ApiError('이름 변경 실패.', res.status);
+
+  const json = (await res.json()) as { data: UserProfile };
+  return json.data;
+};
+
+export const updateProfileImage = async (
+  body: UpdateProfileImageRequest,
+  accessToken: string,
+): Promise<UserProfile> => {
+  const res = await fetch(`${BASE_URL}/api/v1/users/me/profile-image`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) throw new ApiError('프로필 이미지 변경 실패.', res.status);
+
+  const json = (await res.json()) as { data: UserProfile };
+  return json.data;
+};
+
+export const updatePassword = async (
+  body: UpdatePasswordRequest,
+  accessToken: string,
+): Promise<void> => {
+  const res = await fetch(`${BASE_URL}/api/v1/users/me/password`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) throw new ApiError('비밀번호 변경 실패.', res.status);
+};

--- a/src/apis/user/user.type.ts
+++ b/src/apis/user/user.type.ts
@@ -1,0 +1,19 @@
+export interface UserProfile {
+  email: string;
+  name: string;
+  picture: string | null;
+}
+
+export interface UpdateNameRequest {
+  name: string;
+}
+
+export interface UpdateProfileImageRequest {
+  fileId: number;
+}
+
+export interface UpdatePasswordRequest {
+  currentPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+}

--- a/src/app/(after-login)/mypage/page.tsx
+++ b/src/app/(after-login)/mypage/page.tsx
@@ -1,3 +1,276 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { useGetMe } from '@/apis/auth/auth.queries';
+import { useUploadFileMutation } from '@/apis/file/file.queries';
+import {
+  useUpdateNameMutation,
+  useUpdateProfileImageMutation,
+  useUpdatePasswordMutation,
+} from '@/apis/user/user.queries';
+import Button from '@/components/Buttons';
+import Icon from '@/components/Icon';
+import Input from '@/components/Input';
+import { isApiError } from '@/utils/apiError';
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+
 export default function Page() {
-  return <div>마이페이지</div>;
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { data: meData } = useGetMe();
+  const user = meData?.data;
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const selectedFileRef = useRef<File | null>(null);
+  const [hasSelectedFile, setHasSelectedFile] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  const [name, setName] = useState('');
+  const [initialName, setInitialName] = useState('');
+
+  useEffect(() => {
+    if (!user) return;
+
+    setName(user.name);
+    setInitialName(user.name);
+
+    if (!selectedFileRef.current) {
+      if (user.picture) {
+        const url = user.picture.startsWith('http') ? user.picture : `${BASE_URL}${user.picture}`;
+        setPreviewUrl(url);
+      } else {
+        setPreviewUrl(null);
+      }
+    }
+  }, [user]);
+
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [currentPasswordError, setCurrentPasswordError] = useState('');
+  const [newPasswordError, setNewPasswordError] = useState('');
+  const [confirmPasswordError, setConfirmPasswordError] = useState('');
+
+  const [isProfileLoading, setIsProfileLoading] = useState(false);
+  const [isPasswordLoading, setIsPasswordLoading] = useState(false);
+
+  const { mutateAsync: uploadFile } = useUploadFileMutation();
+  const { mutateAsync: updateProfileImage } = useUpdateProfileImageMutation();
+  const { mutateAsync: updateName } = useUpdateNameMutation();
+  const { mutateAsync: updatePassword } = useUpdatePasswordMutation();
+
+  const isNameChanged = name !== initialName;
+  const isImageChanged = hasSelectedFile;
+  const isProfileChanged = isNameChanged || isImageChanged;
+  const isNameEmpty = name.trim() === '';
+  const isProfileSaveDisabled = !isProfileChanged || isNameEmpty;
+  const isPasswordFilled =
+    currentPassword.length > 0 && newPassword.length > 0 && confirmPassword.length > 0;
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    selectedFileRef.current = file;
+    setHasSelectedFile(true);
+    const reader = new FileReader();
+    reader.onload = () => setPreviewUrl(reader.result as string);
+    reader.readAsDataURL(file);
+  };
+
+  const handleProfileSave = async () => {
+    setIsProfileLoading(true);
+    try {
+      const tasks: Promise<unknown>[] = [];
+
+      if (isImageChanged && selectedFileRef.current) {
+        tasks.push(
+          uploadFile({ file: selectedFileRef.current, type: 'PROFILE' })
+            .then((res: { fileId: number }) => updateProfileImage({ fileId: res.fileId }))
+            .catch((err: unknown) => {
+              if (isApiError(err) && err.status === 400) {
+                toast.error('허용되지 않은 파일 형식입니다.');
+              } else if (isApiError(err) && err.status === 404) {
+                toast.error('파일을 찾을 수 없습니다.');
+              } else {
+                toast.error('프로필 이미지 변경에 실패했습니다.');
+              }
+              throw err;
+            }),
+        );
+      }
+
+      if (isNameChanged) {
+        tasks.push(
+          updateName({ name }).catch((err: unknown) => {
+            toast.error('이름 변경에 실패했습니다.');
+            throw err;
+          }),
+        );
+      }
+
+      await Promise.all(tasks);
+      toast.success('프로필이 수정되었습니다.');
+      selectedFileRef.current = null;
+      setHasSelectedFile(false);
+
+      await queryClient.invalidateQueries({ queryKey: ['auth', 'me'] });
+      router.refresh();
+    } catch {
+    } finally {
+      setIsProfileLoading(false);
+    }
+  };
+
+  const handlePasswordSave = async () => {
+    setCurrentPasswordError('');
+    setNewPasswordError('');
+    setConfirmPasswordError('');
+
+    if (newPassword !== confirmPassword) {
+      setConfirmPasswordError('새 비밀번호가 일치하지 않습니다.');
+      return;
+    }
+
+    setIsPasswordLoading(true);
+    try {
+      await updatePassword({ currentPassword, newPassword, confirmPassword });
+      toast.success('비밀번호가 변경되었습니다.');
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+    } catch (err: unknown) {
+      if (isApiError(err) && err.status === 401) {
+        setCurrentPasswordError('현재 비밀번호가 일치하지 않습니다.');
+      } else if (isApiError(err) && err.status === 400) {
+        setNewPasswordError('비밀번호는 영문, 숫자, 특수문자 포함 6자 이상입니다.');
+      } else {
+        toast.error('비밀번호 변경에 실패했습니다.');
+      }
+    } finally {
+      setIsPasswordLoading(false);
+    }
+  };
+
+  return (
+    <div className='mb-12 w-full max-w-3xl p-3 md:p-5'>
+      <button
+        onClick={() => router.back()}
+        className='text-md mb-3 flex cursor-pointer items-center gap-2 font-medium text-gray-500 md:mb-5 md:text-lg'
+      >
+        <Icon name='arrowLeft' size={16} className='md:h-4.5 md:w-4.5' />
+        돌아가기
+      </button>
+
+      <section className='mb-8 rounded-xl border border-gray-200 bg-white p-6 md:p-8'>
+        <h2 className='text-black-200 mb-6 text-lg font-semibold md:text-xl'>프로필</h2>
+
+        <div className='flex flex-col items-center gap-6 sm:flex-row sm:items-start sm:gap-8'>
+          <div className='shrink-0'>
+            <input
+              ref={fileInputRef}
+              type='file'
+              accept='image/*'
+              className='hidden'
+              onChange={handleFileChange}
+            />
+            <div
+              className='group relative h-24 w-24 cursor-pointer rounded-full border border-gray-300 bg-gray-100 md:h-28 md:w-28'
+              onClick={() => fileInputRef.current?.click()}
+            >
+              {previewUrl && (
+                <Image
+                  src={previewUrl}
+                  alt='프로필 이미지'
+                  fill
+                  className='rounded-full object-cover'
+                />
+              )}
+              <div className='absolute inset-0 hidden items-center justify-center rounded-full bg-black/30 group-hover:flex'>
+                <Icon name='plus' size={28} className='text-white' />
+              </div>
+            </div>
+          </div>
+
+          <div className='w-full flex-1 space-y-1'>
+            <Input
+              label='이메일'
+              type='email'
+              value={user?.email ?? ''}
+              readOnly
+              disabled
+              className='bg-gray-50 text-gray-400'
+            />
+            <Input
+              label='이름'
+              type='text'
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder='이름을 입력하세요'
+            />
+            <Button
+              className='w-full'
+              disabled={isProfileSaveDisabled}
+              loading={isProfileLoading}
+              onClick={handleProfileSave}
+            >
+              저장
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <section className='rounded-xl border border-gray-200 bg-white p-6 md:p-8'>
+        <h2 className='text-black-200 mb-6 text-lg font-semibold md:text-xl'>비밀번호 변경</h2>
+
+        <div className='space-y-2'>
+          <Input
+            label='현재 비밀번호'
+            type='password'
+            value={currentPassword}
+            onChange={(e) => {
+              setCurrentPassword(e.target.value);
+              if (currentPasswordError) setCurrentPasswordError('');
+            }}
+            placeholder='현재 비밀번호 입력'
+            error={currentPasswordError}
+          />
+          <Input
+            label='새 비밀번호'
+            type='password'
+            value={newPassword}
+            onChange={(e) => {
+              setNewPassword(e.target.value);
+              if (newPasswordError) setNewPasswordError('');
+            }}
+            placeholder='영문, 숫자, 특수문자(!@#$%^&*) 포함 6자 이상'
+            error={newPasswordError}
+          />
+          <Input
+            label='새 비밀번호 확인'
+            type='password'
+            value={confirmPassword}
+            onChange={(e) => {
+              setConfirmPassword(e.target.value);
+              if (confirmPasswordError) setConfirmPasswordError('');
+            }}
+            placeholder='새 비밀번호 입력'
+            error={confirmPasswordError}
+          />
+          <Button
+            className='mt-1.5 w-full'
+            disabled={!isPasswordFilled}
+            loading={isPasswordLoading}
+            onClick={handlePasswordSave}
+          >
+            저장
+          </Button>
+        </div>
+      </section>
+    </div>
+  );
 }

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -25,6 +25,7 @@ export const authOptions: NextAuthOptions = {
             id: String(user.userId),
             email: user.email,
             name: user.name,
+            picture: null,
             accessToken: user.accessToken,
           };
         } catch {
@@ -39,12 +40,14 @@ export const authOptions: NextAuthOptions = {
       if (user) {
         token.accessToken = user.accessToken;
         token.userId = user.id;
+        token.picture = null;
       }
       return token;
     },
     async session({ session, token }) {
       session.accessToken = token.accessToken;
       session.user.id = token.userId;
+      session.user.picture = (token.picture as string | null) ?? null;
       return session;
     },
   },

--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -44,8 +44,8 @@ export default function Dropdown({
           <li
             key={opt}
             onClick={() => {
-              onSelect(opt);
               setOpen!(false);
+              onSelect(opt);
             }}
             className={cn(
               'mt-0.75 box-border flex cursor-pointer items-center justify-center truncate rounded-md text-sm leading-6.5 last:mb-0.75 md:mt-1 md:text-lg md:last:mb-1',

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -21,6 +21,7 @@ function useWorkspaceId(): number | null {
 }
 
 function LandingHeader() {
+  const pathname = usePathname();
   const { data: meData, isLoading } = useGetMe();
   const user = meData?.data;
 
@@ -47,7 +48,7 @@ function LandingHeader() {
       {isLoading ? (
         <HeaderSkeleton />
       ) : user ? (
-        <HeaderUserProfile name={user.name} picture={user.picture} />
+        <HeaderUserProfile key={pathname} name={user.name} picture={user.picture} />
       ) : (
         <div className='text-md flex items-center gap-4 text-gray-500 md:gap-8 md:text-lg'>
           <Link href='/login' className='hover:text-black-200 transition-all duration-200'>
@@ -63,6 +64,7 @@ function LandingHeader() {
 }
 
 function WorkspaceDetailHeader() {
+  const pathname = usePathname();
   const router = useRouter();
   const workspaceId = useWorkspaceId();
   const { data: wsData, isLoading: wsLoading } = useGetWorkspace(workspaceId ?? 0);
@@ -117,7 +119,7 @@ function WorkspaceDetailHeader() {
         {meLoading ? (
           <HeaderSkeleton />
         ) : (
-          user && <HeaderUserProfile name={user.name} picture={user.picture} />
+          user && <HeaderUserProfile key={pathname} name={user.name} picture={user.picture} />
         )}
       </div>
     </div>
@@ -125,6 +127,7 @@ function WorkspaceDetailHeader() {
 }
 
 function WorkspaceListHeader() {
+  const pathname = usePathname();
   const { data: meData, isLoading } = useGetMe();
   const user = meData?.data;
 
@@ -137,7 +140,7 @@ function WorkspaceListHeader() {
         {isLoading ? (
           <HeaderSkeleton />
         ) : (
-          user && <HeaderUserProfile name={user.name} picture={user.picture} />
+          user && <HeaderUserProfile key={pathname} name={user.name} picture={user.picture} />
         )}
       </div>
     </div>
@@ -162,7 +165,7 @@ export default function Header() {
   return (
     <header
       className={cn(
-        'fixed top-0 right-0 h-15 border-b border-gray-300 bg-white md:h-17.5',
+        'fixed top-0 right-0 z-10 h-15 border-b border-gray-300 bg-white md:h-17.5',
         isLanding
           ? 'left-0 pr-4 pl-[23.5px] md:pr-15 md:pl-6'
           : 'left-16.75 pr-4 pl-6 md:left-40 md:pr-7 md:pl-10 lg:left-75 lg:pr-12',

--- a/src/components/header/HeaderUserProfile.tsx
+++ b/src/components/header/HeaderUserProfile.tsx
@@ -37,7 +37,6 @@ export default function HeaderUserProfile({ name, picture }: HeaderUserProfilePr
   }, []);
 
   const handleSelect = async (value: string) => {
-    setOpen(false);
     if (value === '마이페이지') {
       router.push('/mypage');
     } else if (value === '로그아웃') {

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -8,6 +8,7 @@ declare module 'next-auth' {
       id: string;
       email: string;
       name: string;
+      picture: string | null;
     };
   }
 
@@ -16,6 +17,7 @@ declare module 'next-auth' {
     email: string;
     name: string;
     accessToken: string;
+    picture: string | null;
   }
 }
 

--- a/src/utils/apiError.ts
+++ b/src/utils/apiError.ts
@@ -1,0 +1,10 @@
+export class ApiError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}
+
+export const isApiError = (err: unknown): err is ApiError => err instanceof ApiError;


### PR DESCRIPTION
## ❓이슈
<!-- 해당 PR이 특정 이슈를 해결하는 경우, 이슈 번호를 작성해 주세요. -->

- close #37 

## :memo: Description

<!-- 어떤 내용의 PR인지 작성해 주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

`/mypage` 페이지 반응형 구현 및 프로필·비밀번호 변경 API 연동

크게 **프로필 변경 섹션**과 **비밀번호 변경 섹션**으로 나뉘며,
각 섹션에 필요한 API 레이어(`file`, `user`)도 함께 작성했습니다.
작업 중 발견된 드롭다운 버그와 헤더 z-index 이슈도 함께 수정했습니다.

---

| 메서드 | 엔드포인트 | 설명 |
|--------|-----------|------|
| POST | `/api/v1/files?type=PROFILE` | 파일 업로드 → `fileId` 반환 |
| PATCH | `/api/v1/users/me/profile-image` | 프로필 이미지 변경 |
| PATCH | `/api/v1/users/me` | 이름 수정 |
| PATCH | `/api/v1/users/me/password` | 비밀번호 변경 |

---

## 🗂️ 구현 상세

### 1. 공통 에러 처리 — `apiError.ts`

`fetch`가 `!res.ok`일 때 `status`를 담은 `ApiError`를 throw하고, `catch (err: unknown)` 블록에서 `isApiError(err)`로 타입을 좁혀 에러 코드별 분기 처리합니다. `any` 타입 없이 타입 안전하게 에러를 다룰 수 있도록 설계했습니다.

### 2. 파일 업로드 플로우
파일 선택 → POST /api/v1/files?type=PROFILE
→ fileId 반환
→ PATCH /api/v1/users/me/profile-image { fileId }

`type=PROFILE`일 때는 `workspaceId` 없이 요청합니다. 추후 영수증 업로드 시 `type=RECEIPT`, `workspaceId` 전달만으로 동일 함수를 재사용할 수 있도록 설계했습니다.

### 3. 저장 버튼 활성화 조건

| 조건 | 버튼 상태 |
|------|-----------|
| 이미지·이름 모두 변경 없음 | disabled |
| 이름이 빈 문자열 | disabled |
| 이미지 또는 이름 하나 이상 변경 | enabled |
| 요청 중 | loading |

### 4. 프로필 저장 시 동시 요청

```ts
await Promise.all([
  // 이미지가 변경된 경우만
  uploadFile({ file, type: 'PROFILE' }).then(({ fileId }) =>
    updateProfileImage({ fileId })
  ),
  // 이름이 변경된 경우만
  updateName({ name }),
]);
```

두 요청 중 하나라도 실패하면 해당 에러 토스트만 표시하고, 나머지 성공한 요청은 유지됩니다.

### 5. 저장 성공 후 즉시 갱신

```ts
await queryClient.invalidateQueries({ queryKey: ['auth', 'me'] });
router.refresh();
```

`invalidateQueries`로 `useGetMe()` 캐시를 무효화해 헤더의 `HeaderUserProfile`(이름·이미지)이 새로고침 없이 즉시 갱신됩니다.

### 6. 이름·이미지 초기값 동기화

`useSession()` 대신 `useGetMe()`를 기준으로 `useEffect`에서 초기화합니다. `invalidateQueries` 후 `useGetMe()`가 최신 데이터를 다시 받아오면 effect가 재실행되어 저장 후 이름·이미지가 자동으로 업데이트됩니다.

### 7. 비밀번호 변경 에러 처리

| 상황 | 위치 | 메시지 |
|------|------|--------|
| 새 비밀번호 ≠ 확인 (클라이언트) | 새 비밀번호 확인 하단 | `새 비밀번호가 일치하지 않습니다.` |
| 401 | 현재 비밀번호 하단 | `현재 비밀번호가 일치하지 않습니다.` |
| 400 | 새 비밀번호 하단 | `비밀번호는 영문, 숫자, 특수문자 포함 6자 이상입니다.` |
| 기타 | 토스트 | `비밀번호 변경에 실패했습니다.` |

### 8. 버그 수정

**드롭다운 닫힘 순서**
`onSelect` 호출 전에 `setOpen(false)`를 먼저 실행하도록 순서를 변경했습니다. 기존에는 `router.push()` 호출 후 컴포넌트가 언마운트되면서 `setOpen`이 무시되어 특정 페이지에서 드롭다운이 닫히지 않는 문제가 있었습니다.

**헤더 z-index**
`header`에 `z-10`을 추가해 `Image` 컴포넌트의 stacking context 위로 올라오도록 수정했습니다.

**HeaderUserProfile 드롭다운 경로 변경 시 닫힘**
`key={pathname}`을 사용해 경로가 변경될 때 컴포넌트를 리마운트시켜 `open` state가 `false`로 초기화되도록 했습니다.

<img width="2110" height="1723" alt="image" src="https://github.com/user-attachments/assets/6eb02415-ba32-418d-8d1e-77607764cf02" />


## :cyclone: PR Type
어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## :white_check_mark: Checklist

### PR Checklist

<!-- 작성 중인 PR인 경우, Draft 모드로 생성해 주세요. -->
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] Branch Convention 확인
  > `feat/` 기능 구현, `fix/` 버그 수정, `refactor/` 개선
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist

- [x] 로컬 작동 확인
