### PR TITLE
[#40] Feat/40/공통컴포넌트 아바타

### DIFF
--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import Image from 'next/image';
+import { cn } from '@/utils/cn';
+import Icon from './Icon';
+
+interface AvatarProps {
+  name: string;
+  picture: string | null;
+  member?: boolean;
+}
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
+
+export default function Avatar({ name, picture, member = false }: AvatarProps) {
+  const imageUrl = picture
+    ? picture.startsWith('http')
+      ? picture
+      : `${BASE_URL}${picture}`
+    : null;
+
+  return (
+    <div className={cn('flex max-w-42.5 items-center gap-2')}>
+      {imageUrl ? (
+        <div
+          className={cn(
+            'relative shrink-0 overflow-hidden rounded-full',
+            member ? 'h-8.5 w-8.5 md:h-9.5 md:w-9.5' : 'h-7.5 w-7.5',
+          )}
+        >
+          <Image src={imageUrl} alt={name} sizes='30px' fill className='object-cover' />
+        </div>
+      ) : (
+        <Icon
+          name='profile'
+          className={cn(member ? 'h-8.5 w-8.5 md:h-9.5 md:w-9.5' : 'h-7.5 w-7.5')}
+        />
+      )}
+      <div className={cn(member ? 'text-md md:text-lg' : 'text-md')}>{name}</div>
+    </div>
+  );
+}

--- a/src/components/ReceiptPayInfo.tsx
+++ b/src/components/ReceiptPayInfo.tsx
@@ -2,10 +2,12 @@
 
 import { useState } from 'react';
 import { useParams } from 'next/navigation';
+import { useGetMe } from '@/apis/auth/auth.queries';
 import { useGetReceiptDetail } from '@/apis/receipt/receipt.queries';
 import { ReceiptUploadResponse } from '@/apis/receipt/receipt.type';
 import useMediaQuery from '@/hooks/useMediaQuery';
 import { cn } from '@/utils/cn';
+import Avatar from './Avatar';
 import Icon from './Icon';
 import ResultChip from './ResultChip';
 import StatusChip from './StatusChip';
@@ -63,6 +65,8 @@ export default function ReceiptPayInfo({ editable = false, uploadData }: ReciptP
   });
   const data = editable ? uploadData : detailQuery.data?.data;
 
+  const { data: meData } = useGetMe();
+
   function handleEditClick(field: EditableField, currentValue: string) {
     setEditingField((prev) => {
       const keepEditing = new Set(prev);
@@ -95,7 +99,9 @@ export default function ReceiptPayInfo({ editable = false, uploadData }: ReciptP
       {isLg ? (
         <div className={cn('grid grid-cols-2')}>
           <div className={cn('flex flex-col gap-4')}>
-            <InfoItem label='게시자'>홍길동</InfoItem>
+            <InfoItem label='게시자'>
+              <Avatar name={meData?.data.name ?? ''} picture={meData?.data?.picture ?? null} />
+            </InfoItem>
             <InfoItem label='AI 분석 결과'>
               <ResultChip reasons={data.inappropriateReasons} />
             </InfoItem>
@@ -103,7 +109,7 @@ export default function ReceiptPayInfo({ editable = false, uploadData }: ReciptP
               <StatusChip status={data.status} />
             </InfoItem>
           </div>
-          <div className={cn('flex min-w-0 flex-col gap-4')}>
+          <div className={cn('text-md flex min-w-0 flex-col gap-4')}>
             <InfoItem
               label='결제일'
               editable={editable}
@@ -169,8 +175,10 @@ export default function ReceiptPayInfo({ editable = false, uploadData }: ReciptP
           </div>
         </div>
       ) : (
-        <div className={cn('flex min-w-0 flex-col gap-4')}>
-          <InfoItem label='게시자'>홍길동</InfoItem>
+        <div className={cn('text-md flex min-w-0 flex-col gap-4')}>
+          <InfoItem label='게시자'>
+            <Avatar name={meData?.data.name ?? ''} picture={meData?.data?.picture ?? null} />
+          </InfoItem>
           <InfoItem
             label='결제일'
             editable={editable}


### PR DESCRIPTION
## ❓이슈
<!-- 해당 PR이 특정 이슈를 해결하는 경우, 이슈 번호를 작성해 주세요. -->

- close #40 

## :memo: Description

### 변경된 파일
| 파일 | 변경 내용 |
|-------|-------|
| `ReceiptPayInfo.tsx` | 아바타 컴포넌트 부착 및 글자 css 수정 |
| 'Avatar.tsx' | 아바타 컴포넌트 신규 구현 |
| `next-auth.d.ts` | `picture` 타입 추가 |

### 아바타 컴포넌트
<img width="600" height="300" alt="스크린샷 2026-05-14 142127" src="https://github.com/user-attachments/assets/e8f35a12-4b19-416f-a730-28a6958586cd" />

- 유저의 이름과 프로필 이미지를 가져와서 보여줌  

### 결제 정보 카드와 워크스페이스 관리 페이지 분기
<p float="left">
  <img src="https://github.com/user-attachments/assets/accdb8f4-3f7a-4b09-b34b-258ef56d86c0" width="45%" />
  <img src="https://github.com/user-attachments/assets/dbb2aabf-8e19-4a61-8af8-23da2877b846" width="45%" />
</p>

- 위: 결제 정보 카드, 아래: 워크스페이스 관리 페이지
- 왼쪽: 모바일 사이즈, 오른쪽: md사이즈

### 테스트 코드
#### 결제 정보 카드
```tsx
<Avatar name={meData?.data.name ?? ''} picture={meData?.data?.picture ?? null} />
```

#### 워크스페이스 관리 페이지
```tsx
<Avatar name={meData?.data.name ?? ''} picture={meData?.data?.picture ?? null} member />
```

- `member`로 구분
- 실제 사용할 때는 "멤버 및 초대 목록 조회" API 연결해서 사용
  - 이번에는 임의로 `ReceiptPayInfo.tsx`에서 테스트 진행했음

## :cyclone: PR Type
어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## :white_check_mark: Checklist

### PR Checklist

<!-- 작성 중인 PR인 경우, Draft 모드로 생성해 주세요. -->
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] Branch Convention 확인
  > `feat/` 기능 구현, `fix/` 버그 수정, `refactor/` 개선
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist

- [x] 로컬 작동 확인
