### PR TITLE
[#44] Feat/44/워크스페이스관리페이지

### DIFF
--- a/src/apis/workspace/workspace.queries.ts
+++ b/src/apis/workspace/workspace.queries.ts
@@ -4,6 +4,7 @@ import { workspaceService } from './workspace.service';
 import {
   CreateWorkspaceRequest,
   InviteWorkspaceRequest,
+  UpdateWorkspaceSettingsRequest,
   WorkspaceMemberStatus,
 } from './workspace.type';
 
@@ -66,6 +67,18 @@ export const useGetAdminName = (workspaceId: number) => {
   });
 };
 
+export const useGetWorkspaceMembers = (workspaceId: number, status: WorkspaceMemberStatus) => {
+  const { data: session } = useSession();
+  const accessToken = session?.accessToken as string | undefined;
+
+  return useQuery({
+    queryKey: workspaceKeys.members(workspaceId, status),
+    queryFn: () => workspaceService.getWorkspaceMembers(workspaceId, status, accessToken!),
+    enabled: !!accessToken && !!workspaceId,
+    staleTime: 1000 * 60 * 5,
+  });
+};
+
 export const useCreateWorkspace = () => {
   const { data: session } = useSession();
   const accessToken = session?.accessToken as string | undefined;
@@ -123,14 +136,41 @@ export const useRejectInvitation = () => {
   });
 };
 
-export const useGetWorkspaceMembers = (workspaceId: number, status: WorkspaceMemberStatus) => {
+export const useUpdateWorkspaceSettings = (workspaceId: number) => {
+  const { data: session } = useSession();
+  const accessToken = session?.accessToken as string | undefined;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (body: UpdateWorkspaceSettingsRequest) =>
+      workspaceService.updateWorkspaceSettings(workspaceId, body, accessToken!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: workspaceKeys.detail(workspaceId) });
+      queryClient.invalidateQueries({ queryKey: workspaceKeys.my });
+    },
+  });
+};
+
+export const useDeleteWorkspaceMember = (workspaceId: number) => {
   const { data: session } = useSession();
   const accessToken = session?.accessToken as string | undefined;
 
-  return useQuery({
-    queryKey: workspaceKeys.members(workspaceId, status),
-    queryFn: () => workspaceService.getWorkspaceMembers(workspaceId, status, accessToken!),
-    enabled: !!accessToken && !!workspaceId,
-    staleTime: 1000 * 60 * 5,
+  return useMutation({
+    mutationFn: (userId: number) =>
+      workspaceService.deleteWorkspaceMember(workspaceId, userId, accessToken!),
+  });
+};
+
+export const useDeleteWorkspace = () => {
+  const { data: session } = useSession();
+  const accessToken = session?.accessToken as string | undefined;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (workspaceId: number) =>
+      workspaceService.deleteWorkspace(workspaceId, accessToken!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: workspaceKeys.my });
+    },
   });
 };

--- a/src/apis/workspace/workspace.service.ts
+++ b/src/apis/workspace/workspace.service.ts
@@ -10,6 +10,10 @@ import {
   AdminNameResponse,
   WorkspaceMembersResponse,
   WorkspaceMemberStatus,
+  UpdateWorkspaceSettingsRequest,
+  UpdateWorkspaceSettingsResponse,
+  DeleteWorkspaceMemberResponse,
+  DeleteWorkspaceResponse,
 } from './workspace.type';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
@@ -131,6 +135,57 @@ export const workspaceService = {
     );
 
     if (!res.ok) throw new Error('멤버 목록 조회에 실패했습니다.');
+    return res.json();
+  },
+
+  updateWorkspaceSettings: async (
+    workspaceId: number,
+    body: UpdateWorkspaceSettingsRequest,
+    accessToken: string,
+  ): Promise<UpdateWorkspaceSettingsResponse> => {
+    const res = await fetch(`${BASE_URL}/api/v1/workspaces/${workspaceId}/settings`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (res.status === 403) throw new Error('수정 권한이 없습니다.');
+    if (res.status === 404) throw new Error('워크스페이스를 찾을 수 없습니다.');
+    if (!res.ok) throw new Error('워크스페이스 설정 수정에 실패했습니다.');
+    return res.json();
+  },
+
+  deleteWorkspaceMember: async (
+    workspaceId: number,
+    userId: number,
+    accessToken: string,
+  ): Promise<DeleteWorkspaceMemberResponse> => {
+    const res = await fetch(`${BASE_URL}/api/v1/workspaces/${workspaceId}/members/${userId}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (res.status === 403) throw new Error('강퇴 권한이 없습니다.');
+    if (res.status === 404) throw new Error('멤버를 찾을 수 없습니다.');
+    if (!res.ok) throw new Error('멤버 강퇴에 실패했습니다.');
+    return res.json();
+  },
+
+  deleteWorkspace: async (
+    workspaceId: number,
+    accessToken: string,
+  ): Promise<DeleteWorkspaceResponse> => {
+    const res = await fetch(`${BASE_URL}/api/v1/workspaces/${workspaceId}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (res.status === 403) throw new Error('삭제 권한이 없습니다.');
+    if (res.status === 404) throw new Error('워크스페이스를 찾을 수 없습니다.');
+    if (!res.ok) throw new Error('워크스페이스 삭제에 실패했습니다.');
     return res.json();
   },
 };

--- a/src/apis/workspace/workspace.type.ts
+++ b/src/apis/workspace/workspace.type.ts
@@ -121,3 +121,35 @@ export interface WorkspaceMembersResponse {
     traceId: string;
   };
 }
+
+export interface UpdateWorkspaceSettingsRequest {
+  name: string;
+  color: string;
+}
+
+export interface UpdateWorkspaceSettingsResponse {
+  success: boolean;
+  data: null;
+  meta: {
+    timestamp: string;
+    traceId: string;
+  };
+}
+
+export interface DeleteWorkspaceMemberResponse {
+  success: boolean;
+  data: null;
+  meta: {
+    timestamp: string;
+    traceId: string;
+  };
+}
+
+export interface DeleteWorkspaceResponse {
+  success: boolean;
+  data: null;
+  meta: {
+    timestamp: string;
+    traceId: string;
+  };
+}

--- a/src/app/(after-login)/mypage/page.tsx
+++ b/src/app/(after-login)/mypage/page.tsx
@@ -157,7 +157,7 @@ export default function Page() {
   };
 
   return (
-    <div className='mb-12 w-full max-w-3xl p-3 md:p-5'>
+    <div className='mb-12 w-full max-w-3xl px-6 py-3 md:px-10 md:py-5'>
       <button
         onClick={() => router.back()}
         className='text-md mb-3 flex cursor-pointer items-center gap-2 font-medium text-gray-400 transition-all duration-200 hover:text-gray-500 md:mb-5 md:text-lg'

--- a/src/app/(after-login)/workspace/[workspaceId]/settings/page.tsx
+++ b/src/app/(after-login)/workspace/[workspaceId]/settings/page.tsx
@@ -1,3 +1,295 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'react-toastify';
+import { useParams, useRouter } from 'next/navigation';
+import {
+  useGetWorkspace,
+  useGetWorkspaceMembers,
+  useUpdateWorkspaceSettings,
+  useDeleteWorkspaceMember,
+  useDeleteWorkspace,
+} from '@/apis/workspace/workspace.queries';
+import { WorkspaceMember } from '@/apis/workspace/workspace.type';
+import Avatar from '@/components/Avatar';
+import Button from '@/components/Buttons';
+import ColorChips from '@/components/ColorChips';
+import Icon from '@/components/Icon';
+import Input from '@/components/Input';
+import ConfirmModal from '@/components/modal/contents/ConfirmModal';
+import InviteModal from '@/components/modal/contents/InviteModal';
+import Modal from '@/components/modal/Modal';
+
 export default function Page() {
-  return <div>워크스페이스 관리 페이지</div>;
+  const params = useParams();
+  const router = useRouter();
+  const workspaceId = Number(
+    Array.isArray(params?.workspaceId) ? params.workspaceId[0] : params?.workspaceId,
+  );
+
+  const { data: workspaceData } = useGetWorkspace(workspaceId);
+  const workspace = workspaceData?.data;
+
+  const [name, setName] = useState<string | undefined>(undefined);
+  const [color, setColor] = useState<string | undefined>(undefined);
+
+  const initializedRef = useState(false);
+  if (workspace && !initializedRef[0]) {
+    initializedRef[1](true);
+    if (name === undefined) setName(workspace.workspaceName);
+    if (color === undefined) setColor(workspace.color);
+  }
+
+  const currentName = name ?? workspace?.workspaceName ?? '';
+  const currentColor = color ?? workspace?.color ?? 'GREEN';
+
+  const isSettingsChanged =
+    workspace != null &&
+    (currentName !== workspace.workspaceName || currentColor !== workspace.color);
+
+  const { mutate: updateSettings, isPending: isUpdating } = useUpdateWorkspaceSettings(workspaceId);
+
+  const handleUpdateSettings = () => {
+    updateSettings(
+      { name: currentName, color: currentColor },
+      {
+        onSuccess: () => {
+          toast.success('워크스페이스 설정이 변경되었습니다.');
+        },
+        onError: (error: Error) => {
+          toast.error(error.message || '워크스페이스 설정 변경에 실패했습니다.');
+        },
+      },
+    );
+  };
+
+  const { data: membersData } = useGetWorkspaceMembers(workspaceId, 'ACCEPTED');
+  const [kickedIds, setKickedIds] = useState<number[]>([]);
+  const members: WorkspaceMember[] = (membersData?.data ?? []).filter(
+    (m: WorkspaceMember) => !kickedIds.includes(m.userId),
+  );
+
+  const [kickTarget, setKickTarget] = useState<WorkspaceMember | null>(null);
+  const { mutate: deleteMember } = useDeleteWorkspaceMember(workspaceId);
+
+  const handleKickMember = async (member: WorkspaceMember) => {
+    return new Promise<void>((resolve, reject) => {
+      deleteMember(member.userId, {
+        onSuccess: () => {
+          setKickedIds((prev) => [...prev, member.userId]);
+          toast.success(`${member.name}님을 강퇴했습니다.`);
+          resolve();
+        },
+        onError: (error: Error) => {
+          toast.error(error.message || '멤버 강퇴에 실패했습니다.');
+          reject(error);
+        },
+      });
+    });
+  };
+
+  const { data: pendingData } = useGetWorkspaceMembers(workspaceId, 'PENDING');
+  const [cancelledIds, setCancelledIds] = useState<number[]>([]);
+  const pendingMembers: WorkspaceMember[] = (pendingData?.data ?? []).filter(
+    (m: WorkspaceMember) => !cancelledIds.includes(m.userId),
+  );
+
+  const [cancelTarget, setCancelTarget] = useState<WorkspaceMember | null>(null);
+  const [showInviteModal, setShowInviteModal] = useState(false);
+  const { mutate: cancelInvite } = useDeleteWorkspaceMember(workspaceId);
+
+  const handleCancelInvite = async (member: WorkspaceMember) => {
+    return new Promise<void>((resolve, reject) => {
+      cancelInvite(member.userId, {
+        onSuccess: () => {
+          setCancelledIds((prev) => [...prev, member.userId]);
+          toast.success('초대를 취소했습니다.');
+          resolve();
+        },
+        onError: (error: Error) => {
+          toast.error(error.message || '초대 취소에 실패했습니다.');
+          reject(error);
+        },
+      });
+    });
+  };
+
+  const [showDeleteWorkspaceModal, setShowDeleteWorkspaceModal] = useState(false);
+  const { mutate: deleteWorkspace } = useDeleteWorkspace();
+
+  const handleDeleteWorkspace = async () => {
+    return new Promise<void>((resolve, reject) => {
+      deleteWorkspace(workspaceId, {
+        onSuccess: () => {
+          toast.success('워크스페이스가 삭제되었습니다.');
+          router.push('/workspace');
+          resolve();
+        },
+        onError: (error: Error) => {
+          toast.error(error.message || '워크스페이스 삭제에 실패했습니다.');
+          reject(error);
+        },
+      });
+    });
+  };
+
+  return (
+    <div className='mb-12 w-full max-w-3xl px-6 py-3 md:px-10 md:py-5'>
+      <button
+        onClick={() => router.back()}
+        className='text-md mb-3 flex cursor-pointer items-center gap-2 font-medium text-gray-400 transition-all duration-200 hover:text-gray-500 md:mb-5 md:text-lg'
+      >
+        <Icon name='arrowLeft' size={16} className='md:h-4.5 md:w-4.5' />
+        <span>돌아가기</span>
+      </button>
+
+      <section className='mb-6 rounded-xl border border-gray-200 bg-white p-5 md:p-6'>
+        <h2 className='mb-4 h-6.5 text-lg font-bold md:h-8 md:text-xl'>
+          {workspace?.workspaceName}
+        </h2>
+
+        <div className='flex flex-col gap-3'>
+          <Input
+            label='워크스페이스 이름'
+            type='text'
+            placeholder='워크스페이스 이름을 입력해 주세요'
+            value={currentName}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <ColorChips selected={currentColor} onSelect={setColor} />
+        </div>
+
+        <Button
+          variant='primary'
+          size='lg'
+          className='mt-4 w-full font-medium md:h-12.5 md:text-lg'
+          onClick={handleUpdateSettings}
+          disabled={!isSettingsChanged || !currentName}
+          loading={isUpdating}
+        >
+          변경
+        </Button>
+      </section>
+
+      <section className='mb-6 rounded-xl border border-gray-200 bg-white p-5 md:p-6'>
+        <div className='mb-3 flex items-center justify-between'>
+          <h2 className='text-lg font-bold md:text-xl'>멤버</h2>
+        </div>
+
+        <p className='mb-2 text-sm text-gray-400'>이름</p>
+
+        <div className='scrollbar-hide max-h-55 overflow-y-auto pr-1 md:max-h-60'>
+          {members.length === 0 ? (
+            <p className='py-4 text-center text-sm text-gray-400'>멤버가 없습니다.</p>
+          ) : (
+            <ul className='flex flex-col divide-y divide-gray-100'>
+              {members.map((member) => (
+                <li key={member.userId} className='flex items-center justify-between py-2.5'>
+                  <Avatar name={member.name} picture={member.picture} member className='md:gap-3' />
+                  {member.role !== 'ADMIN' && (
+                    <Button
+                      group='sub'
+                      className='md:text-md w-13 rounded-sm md:h-8 md:w-16'
+                      variant='white'
+                      size='sm'
+                      onClick={() => setKickTarget(member)}
+                    >
+                      삭제
+                    </Button>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
+
+      <section className='mb-6 rounded-xl border border-gray-200 bg-white p-5 md:p-6'>
+        <div className='mb-3 flex items-center justify-between'>
+          <h2 className='text-lg font-bold md:text-xl'>초대 내역</h2>
+          <Button
+            group='sub'
+            className='md:text-md h-6.5 w-18 rounded-sm md:h-8 md:w-21'
+            variant='blue'
+            size='sm'
+            onClick={() => setShowInviteModal(true)}
+          >
+            초대하기
+          </Button>
+        </div>
+
+        <p className='mb-2 text-sm text-gray-400'>이메일</p>
+
+        <div className='scrollbar-hide max-h-49 overflow-y-auto pr-1 md:max-h-53'>
+          {pendingMembers.length === 0 ? (
+            <p className='py-4 text-center text-sm text-gray-400'>초대 내역이 없습니다.</p>
+          ) : (
+            <ul className='flex flex-col divide-y divide-gray-100'>
+              {pendingMembers.map((member) => (
+                <li key={member.userId} className='flex items-center justify-between py-2.5'>
+                  <span className='text-sm md:text-base'>{member.email}</span>
+                  <Button
+                    group='sub'
+                    className='md:text-md w-13 rounded-sm md:h-8 md:w-16'
+                    variant='white'
+                    size='sm'
+                    onClick={() => setCancelTarget(member)}
+                  >
+                    취소
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
+
+      <section className='rounded-xl border border-gray-200 bg-white p-5 md:p-6'>
+        <Button
+          variant='secondary'
+          size='lg'
+          className='w-full md:h-12.5 md:text-lg'
+          onClick={() => setShowDeleteWorkspaceModal(true)}
+        >
+          워크스페이스 삭제하기
+        </Button>
+      </section>
+
+      {kickTarget && (
+        <Modal onClose={() => setKickTarget(null)}>
+          <ConfirmModal
+            message={`${kickTarget.name}님을 삭제하시겠습니까?`}
+            onConfirm={() => handleKickMember(kickTarget)}
+            onClose={() => setKickTarget(null)}
+          />
+        </Modal>
+      )}
+
+      {cancelTarget && (
+        <Modal onClose={() => setCancelTarget(null)}>
+          <ConfirmModal
+            message={`초대를 취소하시겠습니까?`}
+            onConfirm={() => handleCancelInvite(cancelTarget)}
+            onClose={() => setCancelTarget(null)}
+          />
+        </Modal>
+      )}
+
+      {showDeleteWorkspaceModal && (
+        <Modal onClose={() => setShowDeleteWorkspaceModal(false)}>
+          <ConfirmModal
+            message='워크스페이스를 삭제하시겠습니까?'
+            onConfirm={handleDeleteWorkspace}
+            onClose={() => setShowDeleteWorkspaceModal(false)}
+          />
+        </Modal>
+      )}
+
+      {showInviteModal && (
+        <Modal onClose={() => setShowInviteModal(false)}>
+          <InviteModal onClose={() => setShowInviteModal(false)} />
+        </Modal>
+      )}
+    </div>
+  );
 }

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -2,39 +2,44 @@
 
 import Image from 'next/image';
 import { cn } from '@/utils/cn';
-import Icon from './Icon';
 
 interface AvatarProps {
   name: string;
   picture: string | null;
   member?: boolean;
+  className?: string;
 }
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
-export default function Avatar({ name, picture, member = false }: AvatarProps) {
+export default function Avatar({ name, picture, member = false, className }: AvatarProps) {
   const imageUrl = picture
     ? picture.startsWith('http')
       ? picture
       : `${BASE_URL}${picture}`
     : null;
 
+  const initial = name.charAt(0);
+
+  const sizeClass = member ? 'h-8.5 w-8.5 md:h-9.5 md:w-9.5' : 'h-7.5 w-7.5';
+  const textClass = member ? 'text-sm md:text-base' : 'text-xs';
+
   return (
-    <div className={cn('flex max-w-42.5 items-center gap-2')}>
+    <div className={cn('flex max-w-42.5 items-center gap-2', className)}>
       {imageUrl ? (
-        <div
-          className={cn(
-            'relative shrink-0 overflow-hidden rounded-full',
-            member ? 'h-8.5 w-8.5 md:h-9.5 md:w-9.5' : 'h-7.5 w-7.5',
-          )}
-        >
+        <div className={cn('relative shrink-0 overflow-hidden rounded-full', sizeClass)}>
           <Image src={imageUrl} alt={name} sizes='30px' fill className='object-cover' />
         </div>
       ) : (
-        <Icon
-          name='profile'
-          className={cn(member ? 'h-8.5 w-8.5 md:h-9.5 md:w-9.5' : 'h-7.5 w-7.5')}
-        />
+        <div
+          className={cn(
+            'flex shrink-0 items-center justify-center rounded-full bg-blue-100 font-semibold text-blue-200',
+            sizeClass,
+            textClass,
+          )}
+        >
+          {initial}
+        </div>
       )}
       <div className={cn(member ? 'text-md md:text-lg' : 'text-md')}>{name}</div>
     </div>

--- a/src/components/header/HeaderUserProfile.tsx
+++ b/src/components/header/HeaderUserProfile.tsx
@@ -56,7 +56,7 @@ export default function HeaderUserProfile({ name, picture }: HeaderUserProfilePr
           <Image src={imageUrl} alt={name} fill className='object-cover' />
         </div>
       ) : (
-        <div className='md:text-md rounded-ful flex h-7 w-7 shrink-0 items-center justify-center bg-blue-100 text-sm font-semibold text-blue-200 md:h-8 md:w-8'>
+        <div className='md:text-md flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-semibold text-blue-200 md:h-8 md:w-8'>
           {initial}
         </div>
       )}

--- a/src/components/header/HeaderUserProfile.tsx
+++ b/src/components/header/HeaderUserProfile.tsx
@@ -5,7 +5,6 @@ import { signOut } from 'next-auth/react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import Dropdown from '@/components/Dropdown';
-import Icon from '@/components/Icon';
 
 interface HeaderUserProfileProps {
   name: string;
@@ -25,6 +24,8 @@ export default function HeaderUserProfile({ name, picture }: HeaderUserProfilePr
       ? picture
       : `${BASE_URL}${picture}`
     : null;
+
+  const initial = name.charAt(0);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -51,11 +52,13 @@ export default function HeaderUserProfile({ name, picture }: HeaderUserProfilePr
       onClick={() => setOpen((prev) => !prev)}
     >
       {imageUrl ? (
-        <div className='relative h-7 w-7 shrink-0 overflow-hidden rounded-full border border-gray-300 md:h-8 md:w-8'>
+        <div className='relative h-7 w-7 shrink-0 overflow-hidden rounded-full md:h-8 md:w-8'>
           <Image src={imageUrl} alt={name} fill className='object-cover' />
         </div>
       ) : (
-        <Icon name='profile' size={28} className='md:h-8 md:w-8' />
+        <div className='md:text-md rounded-ful flex h-7 w-7 shrink-0 items-center justify-center bg-blue-100 text-sm font-semibold text-blue-200 md:h-8 md:w-8'>
+          {initial}
+        </div>
       )}
 
       <span className='text-black-200 hidden w-20 truncate text-lg font-medium md:block md:text-base'>


### PR DESCRIPTION
## ❓이슈
<!-- 해당 PR이 특정 이슈를 해결하는 경우, 이슈 번호를 작성해 주세요. -->

- close #44 

## :memo: Description

<!-- 어떤 내용의 PR인지 작성해 주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->
`/workspace/{workspaceId}/settings` 페이지를 반응형으로 구현합니다.
워크스페이스 어드민이 이름·색상 변경, 멤버 강퇴, 초대 취소/추가, 워크스페이스 삭제를 한 페이지에서 수행할 수 있습니다.
추가로 프로필 이미지가 없는 유저에 대해 기존 아이콘 대신 이니셜 아바타를 표시하도록 `Avatar`, `HeaderUserProfile` 컴포넌트를 수정했습니다.

## :memo: 구현 상세

### API 레이어 (`apis/workspace/`)

기존 파일에 아래 엔드포인트들을 추가했습니다.

| 메서드 | 엔드포인트 | 설명 |
|---|---|---|
| `GET` | `/api/v1/workspaces/{workspaceId}/members?status={status}` | 멤버 및 초대 내역 조회 |
| `PATCH` | `/api/v1/workspaces/{workspaceId}/settings` | 워크스페이스 이름·색상 수정 |
| `DELETE` | `/api/v1/workspaces/{workspaceId}/members/{userId}` | 멤버 강퇴 및 초대 취소 |
| `DELETE` | `/api/v1/workspaces/{workspaceId}` | 워크스페이스 삭제 |

멤버 강퇴와 초대 취소는 동일한 `DELETE /members/{userId}` 엔드포인트를 공유하므로 `useDeleteWorkspaceMember` 훅 하나로 두 케이스를 처리합니다. `status=ACCEPTED`이면 강퇴, `status=PENDING`이면 초대 취소로 동작합니다.

에러 상태코드별로 `403 / 404 / 기타` 케이스를 분기해 의미 있는 에러 메시지를 throw합니다.

### 페이지 (`settings/page.tsx`)

페이지는 4개의 `<section>`으로 구성됩니다.

#### Section 1 — 워크스페이스 설정 수정

- `useGetWorkspace`로 현재 이름·색상을 가져와 초기값으로 사용합니다.
- `name`, `color` state가 원본과 달라졌을 때만 `isSettingsChanged`가 `true`가 되어 변경 버튼이 활성화됩니다.
- 변경 성공 시 `invalidateQueries`로 워크스페이스 상세 및 목록 캐시를 갱신해 화면에 즉시 반영됩니다.

#### Section 2 — 멤버 조회 및 강퇴

- `useGetWorkspaceMembers(workspaceId, 'ACCEPTED')`로 멤버 목록을 조회합니다.
- 강퇴 성공 시 `kickedIds` 배열에 추가하고 렌더 시 filter로 제거해 별도 refetch 없이 즉시 반영합니다.
- `role === 'ADMIN'`인 멤버는 삭제 버튼을 렌더링하지 않습니다.
- 프로필 이미지는 `Avatar` 컴포넌트를 사용합니다.

#### Section 3 — 초대 내역 및 초대

- `useGetWorkspaceMembers(workspaceId, 'PENDING')`으로 대기 초대 목록을 조회합니다.
- 취소 성공 시 Section 2와 동일하게 `cancelledIds`로 즉시 제거합니다.
- 초대하기 버튼 클릭 시 기존 `InviteModal`을 재사용합니다.

#### Section 4 — 워크스페이스 삭제

- `ConfirmModal` 확인 후 `DELETE /workspaces/{workspaceId}` 요청을 보냅니다.
- 성공 시 토스트 메시지를 표시하고 `/workspace`로 이동합니다.

### 이니셜 아바타 (`Avatar.tsx`, `HeaderUserProfile.tsx`)

프로필 이미지가 없을 때 기존 `profile` 아이콘 대신 `bg-blue-100` 배경에 `text-blue-200` 색상으로 유저 이름 첫 글자를 표시하는 원형 div로 변경했습니다.

### 토스트 & 에러 처리

모든 API 요청의 `onSuccess` / `onError` 콜백에서 `toast.success` / `toast.error`를 호출합니다. 에러 메시지는 서비스 레이어에서 throw한 메시지를 우선 사용하고, 없으면 기본 메시지로 폴백합니다.

<img width="2110" height="2081" alt="image" src="https://github.com/user-attachments/assets/e6aa7b5b-4d2d-4862-bf3d-bfd3af727bf0" />



## :cyclone: PR Type
어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## :white_check_mark: Checklist

### PR Checklist

<!-- 작성 중인 PR인 경우, Draft 모드로 생성해 주세요. -->
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] Branch Convention 확인
  > `feat/` 기능 구현, `fix/` 버그 수정, `refactor/` 개선
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist

- [x] 로컬 작동 확인
