### PR TITLE
[#48] Feat/48/소셜로그인기능

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,13 +1,16 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
   reactCompiler: true,
   images: {
     remotePatterns: [
       {
         protocol: 'https',
         hostname: 'rematedeploy-production.up.railway.app',
+      },
+      {
+        protocol: 'https',
+        hostname: 'lh3.googleusercontent.com',
       },
     ],
   },

--- a/src/apis/workspace/workspace.service.ts
+++ b/src/apis/workspace/workspace.service.ts
@@ -168,9 +168,9 @@ export const workspaceService = {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
 
-    if (res.status === 403) throw new Error('강퇴 권한이 없습니다.');
+    if (res.status === 403) throw new Error('삭제 권한이 없습니다.');
     if (res.status === 404) throw new Error('멤버를 찾을 수 없습니다.');
-    if (!res.ok) throw new Error('멤버 강퇴에 실패했습니다.');
+    if (!res.ok) throw new Error('멤버 삭제에 실패했습니다.');
     return res.json();
   },
 

--- a/src/app/(after-login)/mypage/page.tsx
+++ b/src/app/(after-login)/mypage/page.tsx
@@ -178,17 +178,22 @@ export default function Page() {
               className='hidden'
               onChange={handleFileChange}
             />
+
             <div
-              className='group relative h-24 w-24 cursor-pointer rounded-full border border-gray-300 bg-gray-100 md:h-28 md:w-28'
+              className='group relative h-24 w-24 cursor-pointer rounded-full md:h-28 md:w-28'
               onClick={() => fileInputRef.current?.click()}
             >
-              {previewUrl && (
+              {previewUrl ? (
                 <Image
                   src={previewUrl}
                   alt='프로필 이미지'
                   fill
                   className='rounded-full object-cover'
                 />
+              ) : (
+                <div className='flex h-full w-full items-center justify-center rounded-full bg-blue-100 text-4xl font-medium text-blue-200 md:text-5xl'>
+                  {user?.name?.charAt(0) ?? ''}
+                </div>
               )}
               <div className='absolute inset-0 hidden items-center justify-center rounded-full bg-black/30 group-hover:flex'>
                 <Icon name='plus' size={28} className='text-white' />

--- a/src/app/(after-login)/workspace/[workspaceId]/settings/page.tsx
+++ b/src/app/(after-login)/workspace/[workspaceId]/settings/page.tsx
@@ -77,11 +77,11 @@ export default function Page() {
       deleteMember(member.userId, {
         onSuccess: () => {
           setKickedIds((prev) => [...prev, member.userId]);
-          toast.success(`${member.name}님을 강퇴했습니다.`);
+          toast.success(`${member.name}님을 삭제했습니다.`);
           resolve();
         },
         onError: (error: Error) => {
-          toast.error(error.message || '멤버 강퇴에 실패했습니다.');
+          toast.error(error.message || '멤버 삭제에 실패했습니다.');
           reject(error);
         },
       });

--- a/src/app/(before-login)/(auth)/login/page.tsx
+++ b/src/app/(before-login)/(auth)/login/page.tsx
@@ -20,6 +20,39 @@ interface LoginErrors {
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+function generateState() {
+  return Math.random().toString(36).substring(2);
+}
+
+function handleGoogleLogin() {
+  const state = generateState();
+  sessionStorage.setItem('oauth_state', state);
+
+  const params = new URLSearchParams({
+    client_id: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!,
+    redirect_uri: process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI!,
+    response_type: 'code',
+    scope: 'openid email profile',
+    state,
+  });
+
+  window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params}`;
+}
+
+function handleKakaoLogin() {
+  const state = generateState();
+  sessionStorage.setItem('oauth_state', state);
+
+  const params = new URLSearchParams({
+    client_id: process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY!,
+    redirect_uri: process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI!,
+    response_type: 'code',
+    state,
+  });
+
+  window.location.href = `https://kauth.kakao.com/oauth/authorize?${params}`;
+}
+
 export default function Page() {
   const [form, setForm] = useState<LoginForm>({ email: '', password: '' });
   const [errors, setErrors] = useState<LoginErrors>({});
@@ -131,7 +164,7 @@ export default function Page() {
           <Button
             className='text-black-200 w-full border border-gray-300 bg-white font-medium md:h-12.5 md:text-lg'
             variant='secondary'
-            onClick={() => signIn('google', { callbackUrl: '/workspace' })}
+            onClick={handleGoogleLogin}
           >
             <Icon name='google' className='h-5 w-5 md:h-6 md:w-6' />
             Google로 시작하기
@@ -139,7 +172,7 @@ export default function Page() {
           <Button
             className='text-black-200 w-full border border-gray-300 bg-white font-medium md:h-12.5 md:text-lg'
             variant='secondary'
-            onClick={() => signIn('kakao', { callbackUrl: '/workspace' })}
+            onClick={handleKakaoLogin}
           >
             <Icon name='kakao' className='h-5 w-5 md:h-6 md:w-6' />
             Kakao로 시작하기

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -5,6 +5,7 @@ import { signinApi } from '@/lib/auth-api';
 export const authOptions: NextAuthOptions = {
   providers: [
     CredentialsProvider({
+      id: 'credentials',
       name: 'Credentials',
       credentials: {
         email: { label: 'Email', type: 'email' },
@@ -33,6 +34,29 @@ export const authOptions: NextAuthOptions = {
         }
       },
     }),
+
+    CredentialsProvider({
+      id: 'social',
+      name: 'Social',
+      credentials: {
+        accessToken: { label: 'Access Token', type: 'text' },
+        userId: { label: 'User ID', type: 'text' },
+        email: { label: 'Email', type: 'text' },
+        name: { label: 'Name', type: 'text' },
+        picture: { label: 'Picture', type: 'text' },
+      },
+      async authorize(credentials) {
+        if (!credentials?.accessToken) return null;
+
+        return {
+          id: credentials.userId ?? '',
+          email: credentials.email ?? '',
+          name: credentials.name ?? '',
+          picture: credentials.picture ?? null,
+          accessToken: credentials.accessToken,
+        };
+      },
+    }),
   ],
 
   callbacks: {
@@ -40,7 +64,7 @@ export const authOptions: NextAuthOptions = {
       if (user) {
         token.accessToken = user.accessToken;
         token.userId = user.id;
-        token.picture = null;
+        token.picture = user.picture ?? null;
       }
       return token;
     },

--- a/src/app/oauth/google/page.tsx
+++ b/src/app/oauth/google/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { signIn } from 'next-auth/react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Icon from '@/components/Icon';
+import { socialLoginApi } from '@/lib/auth-api';
+
+export default function GoogleCallbackPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const called = useRef(false);
+
+  useEffect(() => {
+    if (called.current) return;
+    called.current = true;
+
+    const code = searchParams.get('code');
+    const state = searchParams.get('state');
+    const savedState = sessionStorage.getItem('oauth_state');
+
+    if (!code || !state || state !== savedState) {
+      router.replace('/login');
+      return;
+    }
+
+    sessionStorage.removeItem('oauth_state');
+
+    (async () => {
+      try {
+        const res = await socialLoginApi('google', {
+          state,
+          redirectUri: process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI!,
+          token: code,
+        });
+
+        const { accessToken, user } = res.data;
+
+        const result = await signIn('social', {
+          accessToken,
+          userId: String(user.id),
+          email: user.email,
+          name: user.nickname,
+          picture: user.image ?? '',
+          redirect: false,
+        });
+
+        if (result?.error) {
+          router.replace('/login');
+          return;
+        }
+
+        router.replace('/workspace');
+      } catch {
+        router.replace('/login');
+      }
+    })();
+  }, [searchParams, router]);
+
+  return (
+    <div className='flex min-h-dvh items-center justify-center bg-gray-100'>
+      <div className='flex flex-col items-center justify-center gap-8'>
+        <div className='relative'>
+          <div className='relative z-10 flex aspect-square w-20 items-center justify-center rounded-full bg-white shadow-md'>
+            <Icon name='google' className='h-10 w-10' />
+          </div>
+          <span className='absolute top-1/2 left-1/2 h-[80%] w-[80%] -translate-x-1/2 -translate-y-1/2 animate-ping rounded-full bg-blue-100 opacity-75' />
+        </div>
+        <p className='text-center text-gray-400'>Google 로그인 중</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/oauth/google/page.tsx
+++ b/src/app/oauth/google/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { Suspense, useEffect, useRef } from 'react';
 import { signIn } from 'next-auth/react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Icon from '@/components/Icon';
 import { socialLoginApi } from '@/lib/auth-api';
 
-export default function GoogleCallbackPage() {
+function GoogleCallbackInner() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const called = useRef(false);
@@ -69,5 +69,13 @@ export default function GoogleCallbackPage() {
         <p className='text-center text-gray-400'>Google 로그인 중</p>
       </div>
     </div>
+  );
+}
+
+export default function GoogleCallbackPage() {
+  return (
+    <Suspense>
+      <GoogleCallbackInner />
+    </Suspense>
   );
 }

--- a/src/app/oauth/kakao/page.tsx
+++ b/src/app/oauth/kakao/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { Suspense, useEffect, useRef } from 'react';
 import { signIn } from 'next-auth/react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Icon from '@/components/Icon';
 import { socialLoginApi } from '@/lib/auth-api';
 
-export default function KakaoCallbackPage() {
+function KakaoCallbackInner() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const called = useRef(false);
@@ -69,5 +69,13 @@ export default function KakaoCallbackPage() {
         <p className='text-center text-gray-400'>Kakao 로그인 중</p>
       </div>
     </div>
+  );
+}
+
+export default function KakaoCallbackPage() {
+  return (
+    <Suspense>
+      <KakaoCallbackInner />
+    </Suspense>
   );
 }

--- a/src/app/oauth/kakao/page.tsx
+++ b/src/app/oauth/kakao/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { signIn } from 'next-auth/react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Icon from '@/components/Icon';
+import { socialLoginApi } from '@/lib/auth-api';
+
+export default function KakaoCallbackPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const called = useRef(false);
+
+  useEffect(() => {
+    if (called.current) return;
+    called.current = true;
+
+    const code = searchParams.get('code');
+    const state = searchParams.get('state');
+    const savedState = sessionStorage.getItem('oauth_state');
+
+    if (!code || !state || state !== savedState) {
+      router.replace('/login');
+      return;
+    }
+
+    sessionStorage.removeItem('oauth_state');
+
+    (async () => {
+      try {
+        const res = await socialLoginApi('kakao', {
+          state,
+          redirectUri: process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI!,
+          token: code,
+        });
+
+        const { accessToken, user } = res.data;
+
+        const result = await signIn('social', {
+          accessToken,
+          userId: String(user.id),
+          email: user.email,
+          name: user.nickname,
+          picture: user.image ?? '',
+          redirect: false,
+        });
+
+        if (result?.error) {
+          router.replace('/login');
+          return;
+        }
+
+        router.replace('/workspace');
+      } catch {
+        router.replace('/login');
+      }
+    })();
+  }, [searchParams, router]);
+
+  return (
+    <div className='flex min-h-dvh items-center justify-center bg-gray-100'>
+      <div className='flex flex-col items-center justify-center gap-8'>
+        <div className='relative'>
+          <div className='relative z-10 flex aspect-square w-20 items-center justify-center rounded-full bg-white shadow-md'>
+            <Icon name='kakao' className='h-10 w-10' />
+          </div>
+          <span className='absolute top-1/2 left-1/2 h-[80%] w-[80%] -translate-x-1/2 -translate-y-1/2 animate-ping rounded-full bg-blue-100 opacity-75' />
+        </div>
+        <p className='text-center text-gray-400'>Kakao 로그인 중</p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/auth-api.ts
+++ b/src/lib/auth-api.ts
@@ -42,3 +42,41 @@ export async function signinApi(body: SigninRequest): Promise<AuthResponse> {
 
   return data;
 }
+
+export interface SocialLoginRequest {
+  state: string;
+  redirectUri: string;
+  token: string;
+}
+
+export interface SocialAuthResponse {
+  success: boolean;
+  data: {
+    accessToken: string;
+    user: {
+      id: number;
+      email: string;
+      nickname: string;
+      image: string | null;
+    };
+  };
+}
+
+export async function socialLoginApi(
+  provider: 'google' | 'kakao',
+  body: SocialLoginRequest,
+): Promise<SocialAuthResponse> {
+  const res = await fetch(`${API_URL}/api/v1/auth/social/login/${provider}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  const data: SocialAuthResponse = await res.json();
+
+  if (!res.ok || !data.success) {
+    throw new ApiError(res.status, '소셜 로그인에 실패했습니다.');
+  }
+
+  return data;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -44,5 +44,5 @@ export async function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|oauth).*)'],
 };

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -25,5 +25,6 @@ declare module 'next-auth/jwt' {
   interface JWT {
     accessToken: string;
     userId: string;
+    picture?: string | null;
   }
 }


### PR DESCRIPTION
## ❓이슈
<!-- 해당 PR이 특정 이슈를 해결하는 경우, 이슈 번호를 작성해 주세요. -->

- close #48 

## :memo: Description

<!-- 어떤 내용의 PR인지 작성해 주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

Google 및 Kakao 소셜 로그인 기능을 구현합니다.
기존 NextAuth 내장 Provider 방식 대신, OAuth 2.0 인가코드를 백엔드에 전달하는 커스텀 플로우로 구현했습니다.
기존 이메일 로그인과 동일한 세션 구조(`accessToken`, `userId`, `picture`)를 유지합니다.
추가로 마이페이지에서 프로필 이미지가 없을 때 빈 원으로 표시되던 문제를 함께 수정합니다.

### 구현 흐름
로그인 버튼 클릭
│
▼
state 생성 (CSRF 방지) → sessionStorage 저장
│
▼
Google/Kakao OAuth 인가 URL로 window.location.href 리다이렉트
│
▼  (사용자 소셜 계정 인증 완료)
/oauth/google 또는 /oauth/kakao 콜백 페이지 진입
│
├─ URL의 state와 sessionStorage의 state 비교 검증
├─ 백엔드 POST /api/v1/auth/social/login/{provider} 호출
│      body: { state, redirectUri, token(인가코드) }
├─ 응답에서 accessToken, user 정보 수신
│
▼
signIn('social', { accessToken, userId, email, name, picture })
│
▼
NextAuth JWT 세션 생성 → /workspace 이동

### 변경 파일 상세

**`lib/auth-api.ts`**
- `socialLoginApi(provider, body)` 함수 추가
- `SocialLoginRequest`, `SocialAuthResponse` 타입 추가

**`types/next-auth.d.ts`**
- `JWT` 인터페이스에 `picture?: string | null` 필드 추가

**`app/api/auth/[...nextauth]/route.ts`**
- 기존 provider id를 `'credentials'`로 명시
- `'social'` id CredentialsProvider 추가 — 콜백 페이지에서 전달받은 `accessToken`을 그대로 JWT 세션으로 저장
- `jwt` 콜백에서 `picture` 필드 저장 추가

**`app/oauth/google/page.tsx`** (신규)
- Google OAuth 콜백 처리 페이지
- `useRef` 가드로 React Strict Mode 이중 실행 방지
- `state` 검증(CSRF) → `socialLoginApi('google', ...)` → `signIn('social', ...)` → `/workspace` 이동
- 실패 시 `/login`으로 이동

**`app/oauth/kakao/page.tsx`** (신규)
- Google 콜백과 동일한 구조로 Kakao 처리

**`app/(before-login)/(auth)/login/page.tsx`**
- Google/Kakao 버튼 `onClick`을 `signIn('google/kakao')` → `handleGoogleLogin()` / `handleKakaoLogin()`으로 교체
- 각 핸들러에서 `state` 생성 후 `sessionStorage` 저장, OAuth 인가 URL로 리다이렉트

**`middleware.ts`**
- matcher에 `oauth` 제외 추가
- 변경 전: `/((?!api|_next/static|_next/image|favicon.ico).*)`
- 변경 후: `/((?!api|_next/static|_next/image|favicon.ico|oauth).*)`
- `/oauth/google`, `/oauth/kakao` 콜백 페이지가 미들웨어 로그인 리다이렉트에 차단되지 않도록 처리

**`next.config.ts`**
- `images.remotePatterns`에 `lh3.googleusercontent.com` 추가
- Google 소셜 로그인 사용자의 프로필 이미지 로드 허용

**`app/(after-login)/mypage/page.tsx`**
- 프로필 이미지가 없을 때 빈 원 대신 헤더와 동일하게 `bg-blue-100` 배경에 이름 첫 글자 표시

## :cyclone: PR Type
어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## :white_check_mark: Checklist

### PR Checklist

<!-- 작성 중인 PR인 경우, Draft 모드로 생성해 주세요. -->
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] Branch Convention 확인
  > `feat/` 기능 구현, `fix/` 버그 수정, `refactor/` 개선
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist

- [x] 로컬 작동 확인
