### PR TITLE
[#46] Refactor/46/결제정보카드

### DIFF
--- a/src/apis/receipt/receipt.queries.ts
+++ b/src/apis/receipt/receipt.queries.ts
@@ -1,4 +1,4 @@
-import { keepPreviousData, useMutation, useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useSession } from 'next-auth/react';
 import { receiptService } from './receipt.service';
 import { ReceiptListParams } from './receipt.type';
@@ -70,5 +70,27 @@ export const useExportReceipts = () => {
 
   return useMutation({
     mutationFn: (workspaceId: number) => receiptService.exportReceipts(workspaceId, accessToken!),
+  });
+};
+
+export const useUpdateStatus = () => {
+  const { data: session } = useSession();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      workspaceId,
+      status,
+      reason,
+    }: {
+      id: number;
+      workspaceId: number;
+      status: 'APPROVED' | 'REJECTED';
+      reason?: string;
+    }) => receiptService.updateStatus(id, workspaceId, status, session?.accessToken ?? '', reason),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['receipts'] });
+    },
   });
 };

--- a/src/apis/receipt/receipt.service.ts
+++ b/src/apis/receipt/receipt.service.ts
@@ -109,4 +109,26 @@ export const receiptService = {
 
     window.URL.revokeObjectURL(blobUrl);
   },
+
+  updateStatus: async (
+    id: number,
+    workspaceId: number,
+    status: 'APPROVED' | 'REJECTED',
+    accessToken: string,
+    reason?: string,
+  ) => {
+    const updateParams = new URLSearchParams({ workspaceId: String(workspaceId), status });
+
+    if (reason) {
+      updateParams.append('reason', reason);
+    }
+
+    const res = await fetch(`${API_URL}/api/v1/receipts/${id}/status?${updateParams}`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (!res.ok) throw new Error('상태 변경에 실패했습니다.');
+    return res.json();
+  },
 };

--- a/src/apis/receipt/receipt.type.ts
+++ b/src/apis/receipt/receipt.type.ts
@@ -62,6 +62,7 @@ export interface ReceiptDetailResponse {
     discountAmount: number;
     aiReason: string;
     category: string;
+    userPicture: string;
   };
   meta: {
     timestamp: string;

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -27,8 +27,19 @@ export default function Avatar({ name, picture, member = false, className }: Ava
   return (
     <div className={cn('flex max-w-42.5 items-center gap-2', className)}>
       {imageUrl ? (
-        <div className={cn('relative shrink-0 overflow-hidden rounded-full', sizeClass)}>
-          <Image src={imageUrl} alt={name} sizes='30px' fill className='object-cover' />
+        <div
+          className={cn(
+            'relative shrink-0 overflow-hidden rounded-full',
+            member ? 'h-8.5 w-8.5 md:h-9.5 md:w-9.5' : 'h-7.5 w-7.5',
+          )}
+        >
+          <Image
+            src={imageUrl}
+            alt={name}
+            sizes={member ? '100px' : '80px'}
+            fill
+            className='object-cover'
+          />
         </div>
       ) : (
         <div

--- a/src/components/ReceiptPayInfo.tsx
+++ b/src/components/ReceiptPayInfo.tsx
@@ -3,12 +3,16 @@
 import { useState } from 'react';
 import { useParams } from 'next/navigation';
 import { useGetMe } from '@/apis/auth/auth.queries';
-import { useGetReceiptDetail } from '@/apis/receipt/receipt.queries';
-import { ReceiptUploadResponse } from '@/apis/receipt/receipt.type';
+import { useGetReceiptDetail, useUpdateStatus } from '@/apis/receipt/receipt.queries';
+import { ReceiptDetailResponse, ReceiptUploadResponse } from '@/apis/receipt/receipt.type';
+import { useGetWorkspace } from '@/apis/workspace/workspace.queries';
 import useMediaQuery from '@/hooks/useMediaQuery';
 import { cn } from '@/utils/cn';
 import Avatar from './Avatar';
+import Button from './Buttons';
 import Icon from './Icon';
+import ConfirmModal from './modal/contents/ConfirmModal';
+import Modal from './modal/Modal';
 import ResultChip from './ResultChip';
 import StatusChip from './StatusChip';
 
@@ -25,6 +29,7 @@ function InfoItem({
   editable,
   className,
   isEditing,
+  action,
   onEditClick,
 }: {
   label: string;
@@ -32,13 +37,17 @@ function InfoItem({
   editable?: boolean;
   className?: string;
   isEditing?: boolean;
+  action?: React.ReactNode;
   onEditClick?: () => void;
 }) {
   return (
     <div className={cn('flex flex-col gap-1.5')}>
-      <p className={cn('text-black-400 text-xs font-semibold')}>{label}</p>
+      <div className={cn('flex gap-35.5 lg:gap-29')}>
+        <p className={cn('text-black-400 text-xs font-semibold')}>{label}</p>
+        {action}
+      </div>
       <div className={cn('flex gap-0.5')}>
-        <div>{children}</div>
+        <div className='h-7.5'>{children}</div>
         <div>
           {editable === true && (
             <Icon name='edit' size={28} className='cursor-pointer' onClick={onEditClick} />
@@ -64,8 +73,17 @@ export default function ReceiptPayInfo({ editable = false, uploadData }: ReciptP
     enabled: !editable,
   });
   const data = editable ? uploadData : detailQuery.data?.data;
-
   const { data: meData } = useGetMe();
+  const { mutateAsync: updateStatus } = useUpdateStatus();
+  const { data: wsData } = useGetWorkspace(Number(params.workspaceId));
+  const isAdmin = wsData?.data.role === 'ADMIN';
+
+  const [confirmStatus, setConfirmStatus] = useState<'APPROVED' | 'REJECTED' | null>(null);
+  const [rejectReason, setRejectReason] = useState('');
+  const [isRejecting, setIsRejecting] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const showBtn = data?.status === 'WAITING' && isAdmin && !isSaving;
 
   function handleEditClick(field: EditableField, currentValue: string) {
     setEditingField((prev) => {
@@ -95,21 +113,202 @@ export default function ReceiptPayInfo({ editable = false, uploadData }: ReciptP
   }
 
   return (
-    <div className={cn('min-w-[236.5px] rounded-lg border border-gray-300 p-4 lg:max-w-100')}>
-      {isLg ? (
-        <div className={cn('grid grid-cols-2')}>
-          <div className={cn('flex flex-col gap-4')}>
-            <InfoItem label='게시자'>
-              <Avatar name={meData?.data.name ?? ''} picture={meData?.data?.picture ?? null} />
-            </InfoItem>
-            <InfoItem label='AI 분석 결과'>
-              <ResultChip reasons={data.inappropriateReasons} />
-            </InfoItem>
-            <InfoItem label='상태'>
-              <StatusChip status={data.status} />
-            </InfoItem>
+    <div>
+      {confirmStatus && (
+        <Modal onClose={() => setConfirmStatus(null)}>
+          <ConfirmModal
+            message={
+              confirmStatus === 'APPROVED'
+                ? '영수증을 승인하시겠습니까?'
+                : '영수증을 반려하시겠습니까?'
+            }
+            onConfirm={async () => {
+              await updateStatus({
+                id: Number(params.receiptId),
+                workspaceId: Number(params.workspaceId),
+                status: confirmStatus === 'APPROVED' ? 'APPROVED' : 'REJECTED',
+              });
+            }}
+            onClose={() => setConfirmStatus(null)}
+          />
+        </Modal>
+      )}
+
+      <div className={cn('min-w-[236.5px] rounded-lg border border-gray-300 p-4 lg:max-w-100')}>
+        {isLg ? (
+          <div
+            className={cn('grid grid-cols-2 gap-2.5')}
+            style={{ gridTemplateColumns: '55% 45%' }}
+          >
+            <div className={cn('flex flex-col gap-4')}>
+              <InfoItem label='게시자'>
+                <Avatar
+                  name={
+                    editable
+                      ? (meData?.data.name ?? '')
+                      : ((data as ReceiptDetailResponse['data']).userName ?? '')
+                  }
+                  picture={
+                    editable
+                      ? (meData?.data?.picture ?? null)
+                      : ((data as ReceiptDetailResponse['data']).userPicture ?? null)
+                  }
+                />
+              </InfoItem>
+              <InfoItem label='AI 분석 결과'>
+                <ResultChip reasons={data.inappropriateReasons} />
+              </InfoItem>
+              <InfoItem
+                label='상태'
+                action={
+                  isRejecting && (
+                    <Button
+                      group='sub'
+                      variant='blue'
+                      onClick={async () => {
+                        setIsSaving(true);
+                        await updateStatus({
+                          id: Number(params.receiptId),
+                          workspaceId: Number(params.workspaceId),
+                          status: 'REJECTED',
+                          reason: rejectReason,
+                        });
+                        setIsRejecting(false);
+                      }}
+                      className={cn('h-5 w-8.5 rounded-sm text-[10px] leading-4.5 font-medium')}
+                    >
+                      저장
+                    </Button>
+                  )
+                }
+              >
+                {showBtn && !isRejecting ? (
+                  <div className={cn('flex gap-1.5')}>
+                    <Button
+                      group='sub'
+                      variant='blue'
+                      onClick={() => setConfirmStatus('APPROVED')}
+                      className={cn('h-6.5 w-22.75 text-xs font-medium')}
+                    >
+                      승인
+                    </Button>
+                    <Button
+                      group='sub'
+                      variant='white'
+                      onClick={() => setIsRejecting(true)}
+                      className={cn('h-6.5 w-22.75 text-xs font-medium')}
+                    >
+                      반려
+                    </Button>
+                  </div>
+                ) : isRejecting ? (
+                  <input
+                    type='text'
+                    value={rejectReason}
+                    onChange={(e) => setRejectReason(e.target.value)}
+                    placeholder='반려 사유를 입력해주세요'
+                    className={cn(
+                      'text-black-400 rounded-sm border border-gray-300 px-1.5 py-1.25 text-xs placeholder:text-gray-400',
+                    )}
+                  />
+                ) : (
+                  <div className={cn('flex items-center gap-1.5')}>
+                    <StatusChip status={data.status} />
+                    {data.status === 'REJECTED' && data.rejectionReason && (
+                      <span
+                        title={data.rejectionReason}
+                        className={cn('text-md text-black-200 max-w-30 truncate')}
+                      >
+                        {data.rejectionReason}
+                      </span>
+                    )}
+                  </div>
+                )}
+              </InfoItem>
+            </div>
+            <div className={cn('text-md flex flex-col gap-4')}>
+              <InfoItem
+                label='결제일'
+                editable={editable}
+                isEditing={editingField.has('tradeAt')}
+                onEditClick={() => handleEditClick('tradeAt', data.tradeAt)}
+                className='h-6'
+              >
+                {editingField.has('tradeAt') ? (
+                  <input
+                    type='text'
+                    value={tempValue.tradeAt}
+                    onChange={(e) => setTempValue((prev) => ({ ...prev, tradeAt: e.target.value }))}
+                    className={cn(
+                      'text-black-200 h-5 w-full rounded-xl border border-gray-300 px-3.5 py-3 text-lg focus:border-blue-200 focus:outline-none',
+                    )}
+                  />
+                ) : (
+                  formatDate(data.tradeAt)
+                )}
+              </InfoItem>
+              <InfoItem
+                label='가맹점'
+                editable={editable}
+                isEditing={editingField.has('storeName')}
+                onEditClick={() => handleEditClick('storeName', data.storeName)}
+                className='h-6'
+              >
+                {editingField.has('storeName') ? (
+                  <input
+                    type='text'
+                    value={tempValue.storeName}
+                    onChange={(e) =>
+                      setTempValue((prev) => ({ ...prev, storeName: e.target.value }))
+                    }
+                    className={cn(
+                      'text-black-200 h-5 w-full rounded-xl border border-gray-300 px-3.5 py-3 text-lg focus:border-blue-200 focus:outline-none',
+                    )}
+                  />
+                ) : (
+                  data.storeName
+                )}
+              </InfoItem>
+              <InfoItem
+                label='결제 금액'
+                editable={editable}
+                isEditing={editingField.has('totalAmount')}
+                onEditClick={() => handleEditClick('totalAmount', String(data.totalAmount))}
+                className='h-6'
+              >
+                {editingField.has('totalAmount') ? (
+                  <input
+                    type='text'
+                    value={tempValue.totalAmount}
+                    onChange={(e) =>
+                      setTempValue((prev) => ({ ...prev, totalAmount: e.target.value }))
+                    }
+                    className={cn(
+                      'text-black-200 h-5 w-full rounded-xl border border-gray-300 px-3.5 py-3 text-lg focus:border-blue-200 focus:outline-none',
+                    )}
+                  />
+                ) : (
+                  formatAmount(data.totalAmount)
+                )}
+              </InfoItem>
+            </div>
           </div>
+        ) : (
           <div className={cn('text-md flex min-w-0 flex-col gap-4')}>
+            <InfoItem label='게시자'>
+              <Avatar
+                name={
+                  editable
+                    ? (meData?.data.name ?? '')
+                    : ((data as ReceiptDetailResponse['data']).userName ?? '')
+                }
+                picture={
+                  editable
+                    ? (meData?.data?.picture ?? null)
+                    : ((data as ReceiptDetailResponse['data']).userPicture ?? null)
+                }
+              />
+            </InfoItem>
             <InfoItem
               label='결제일'
               editable={editable}
@@ -172,81 +371,77 @@ export default function ReceiptPayInfo({ editable = false, uploadData }: ReciptP
                 formatAmount(data.totalAmount)
               )}
             </InfoItem>
+            <InfoItem label='AI 분석 결과'>
+              <ResultChip reasons={data.inappropriateReasons} />
+            </InfoItem>
+            <InfoItem
+              label='상태'
+              action={
+                isRejecting && (
+                  <Button
+                    group='sub'
+                    variant='blue'
+                    onClick={async () => {
+                      setIsSaving(true);
+                      await updateStatus({
+                        id: Number(params.receiptId),
+                        workspaceId: Number(params.workspaceId),
+                        status: 'REJECTED',
+                        reason: rejectReason,
+                      });
+                      setIsRejecting(false);
+                    }}
+                    className={cn('h-5 w-8.5 rounded-sm text-[10px] leading-4.5 font-medium')}
+                  >
+                    저장
+                  </Button>
+                )
+              }
+            >
+              {showBtn && !isRejecting ? (
+                <div className={cn('flex gap-1.5')}>
+                  <Button
+                    group='sub'
+                    variant='blue'
+                    onClick={() => setConfirmStatus('APPROVED')}
+                    className={cn('h-6.5 w-22.75 text-xs font-medium')}
+                  >
+                    승인
+                  </Button>
+                  <Button
+                    group='sub'
+                    variant='white'
+                    onClick={() => setIsRejecting(true)}
+                    className={cn('h-6.5 w-22.75 text-xs font-medium')}
+                  >
+                    반려
+                  </Button>
+                </div>
+              ) : isRejecting ? (
+                <input
+                  type='text'
+                  value={rejectReason}
+                  onChange={(e) => setRejectReason(e.target.value)}
+                  placeholder='반려 사유를 입력해주세요'
+                  className={cn('rounded-sm border border-gray-300 px-1.5 py-1.25')}
+                />
+              ) : (
+                <div className={cn('flex items-center gap-1.5')}>
+                  <StatusChip status={data.status} />
+                  {data.status === 'REJECTED' && data.rejectionReason && (
+                    <span
+                      title={data.rejectionReason}
+                      className={cn('text-md text-black-200 max-w-37.5 truncate')}
+                    >
+                      {data.rejectionReason}
+                    </span>
+                  )}
+                </div>
+              )}
+            </InfoItem>
           </div>
-        </div>
-      ) : (
-        <div className={cn('text-md flex min-w-0 flex-col gap-4')}>
-          <InfoItem label='게시자'>
-            <Avatar name={meData?.data.name ?? ''} picture={meData?.data?.picture ?? null} />
-          </InfoItem>
-          <InfoItem
-            label='결제일'
-            editable={editable}
-            isEditing={editingField.has('tradeAt')}
-            onEditClick={() => handleEditClick('tradeAt', data.tradeAt)}
-            className='h-6'
-          >
-            {editingField.has('tradeAt') ? (
-              <input
-                type='text'
-                value={tempValue.tradeAt}
-                onChange={(e) => setTempValue((prev) => ({ ...prev, tradeAt: e.target.value }))}
-                className={cn(
-                  'text-black-200 h-5 w-full rounded-xl border border-gray-300 px-3.5 py-3 text-lg focus:border-blue-200 focus:outline-none',
-                )}
-              />
-            ) : (
-              formatDate(data.tradeAt)
-            )}
-          </InfoItem>
-          <InfoItem
-            label='가맹점'
-            editable={editable}
-            isEditing={editingField.has('storeName')}
-            onEditClick={() => handleEditClick('storeName', data.storeName)}
-            className='h-6'
-          >
-            {editingField.has('storeName') ? (
-              <input
-                type='text'
-                value={tempValue.storeName}
-                onChange={(e) => setTempValue((prev) => ({ ...prev, storeName: e.target.value }))}
-                className={cn(
-                  'text-black-200 h-5 w-full rounded-xl border border-gray-300 px-3.5 py-3 text-lg focus:border-blue-200 focus:outline-none',
-                )}
-              />
-            ) : (
-              data.storeName
-            )}
-          </InfoItem>
-          <InfoItem
-            label='결제 금액'
-            editable={editable}
-            isEditing={editingField.has('totalAmount')}
-            onEditClick={() => handleEditClick('totalAmount', String(data.totalAmount))}
-            className='h-6'
-          >
-            {editingField.has('totalAmount') ? (
-              <input
-                type='text'
-                value={tempValue.totalAmount}
-                onChange={(e) => setTempValue((prev) => ({ ...prev, totalAmount: e.target.value }))}
-                className={cn(
-                  'text-black-200 h-5 w-full rounded-xl border border-gray-300 px-3.5 py-3 text-lg focus:border-blue-200 focus:outline-none',
-                )}
-              />
-            ) : (
-              formatAmount(data.totalAmount)
-            )}
-          </InfoItem>
-          <InfoItem label='AI 분석 결과'>
-            <ResultChip reasons={data.inappropriateReasons} />
-          </InfoItem>
-          <InfoItem label='상태'>
-            <StatusChip status={data.status} />
-          </InfoItem>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## ❓이슈
<!-- 해당 PR이 특정 이슈를 해결하는 경우, 이슈 번호를 작성해 주세요. -->

- close #46 

## :memo: Description

### 승인 반려 기능
<img width="804" height="472" alt="image" src="https://github.com/user-attachments/assets/c93a86d0-012f-4af2-b8c7-c1547e5724cf" />
      
- 게시자인 경우 상태가 '대기'인 영수증에 승인/반려 버튼 노출
- 승인 버튼 클릭 시 승인 확인 모달 노출
- 반려 버튼 클릭 시 버튼 대신 `input`과 저장 버튼 노출
- `input`에 반려 사유 작성 후 저장 버튼 누르면 영수증 상태 반려로 변경됨
- 영수증 반려 시 반려 사유가 칩 옆에 노출


### 아바타 수정
1. 사이즈 추가로 화질 저하 수정
2. 기존에는 게시자가 누구든 로그인한 계정의 아바타 노출 -> 게시자 아바타 노출로 수정

### 수정된 파일
#### receipt.queries.ts
- `useUpdateStatus`
영수증 상태를 변경하고 목록 갱신

#### receipt.service.ts
- `updateStatus` 
`/api/v1/receipts/${id}/status`를 호출

#### receipt.type.ts
-`ReceiptDetailResponse`
`userPicture` 추가로 유저의 프로필 사진 가져올 수 있게 함

#### Avatar.tsx
`- Image` 태그에 `size` 추가

#### ReceiptPayInfo
- `action` 추가로 승인/반려 버튼 나타나는 상황 관리
- `showBtn`으로 버튼 노출 여부 결정
- 모달 추가
- 게시자 필드에서 editable인 경우에는 현재 로그인한 유저의 아바타를, 아닌 경우에는 게시자의 아바타를 보여줌
- `isRejecting`이면 반려 사유 입력하는 input과 저장 버튼 노출, 아니면 승인 확인 모달 노출
- 저장 버튼 클릭 시 반려 사유와 상태 저장
- 승인/반려 두 경우 모두 칩 바뀌고, 반려일 경우에는 반려 사유도 함께 노출


## :cyclone: PR Type
어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## :white_check_mark: Checklist

### PR Checklist

<!-- 작성 중인 PR인 경우, Draft 모드로 생성해 주세요. -->
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] Branch Convention 확인
  > `feat/` 기능 구현, `fix/` 버그 수정, `refactor/` 개선
- [x] Base Branch 확인
- [x] 커밋 메시지 컨벤션 준수
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정

### Test Checklist

- [x] 로컬 작동 확인
